### PR TITLE
Remove not necessary dependencies

### DIFF
--- a/app/etc/modules/CustomGento_CoreFixes.xml
+++ b/app/etc/modules/CustomGento_CoreFixes.xml
@@ -5,9 +5,7 @@
             <active>true</active>
             <codePool>community</codePool>
             <depends>
-                <Mage_ConfigurableSwatches/>
                 <Mage_Core/>
-                <Mage_Sales/>
             </depends>
         </CustomGento_CoreFixes>
     </modules>


### PR DESCRIPTION
`Mage_ConfigurableSwatches` was an old unused dependency anyway.

`Mage_Sales` should not be a dependency, because it is not required for our module. If it is not present, our `Sales` rewrites will just be silently ignored, which is totally fine.